### PR TITLE
Fix upgrade subcommand

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -38,6 +38,7 @@ export const nosdumpCommand = new Command()
           package: "@jiftechnify/nosdump",
         }),
       ],
+      args: ["--allow-all"], // grant all permissions while upgrading
     }),
   )
   .command("relay-alias", relayAliasCommand).alias("alias")


### PR DESCRIPTION
This fix make `nosdump upgrade` grant `--allow-all` to the script while upgrading.